### PR TITLE
Update gist.py

### DIFF
--- a/adafruit_pastebin/gist.py
+++ b/adafruit_pastebin/gist.py
@@ -70,6 +70,6 @@ class Gist(_Pastebin):
         json_response = json.loads(response.text)
         try:
             return json_response["html_url"]
-        except KeyError:
+        except KeyError as err:
             error_message = json_response["message"]
-            raise RuntimeError(error_message)
+            raise RuntimeError(error_message) from err

--- a/adafruit_pastebin/gist.py
+++ b/adafruit_pastebin/gist.py
@@ -72,4 +72,4 @@ class Gist(_Pastebin):
             return json_response["html_url"]
         except KeyError:
             error_message = json_response["message"]
-        raise RuntimeError(error_message)
+            raise RuntimeError(error_message)


### PR DESCRIPTION
Fix indentation, which currently now always raises an exception, as opposed to the intended functionality of transforming a `KeyError` to a `RuntimeError`.