### PR TITLE
fix circup instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install pastebin
+    circup install adafruit_pastebin
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
This is one of the last ones revealed by a quick check following up on https://github.com/adafruit/Adafruit_CircuitPython_Bundle/issues/407